### PR TITLE
Update the build task description

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "svl",
+      "label": "svl binary",
       "group": "build",
       "type": "shell",
       "command": "${workspaceFolder}/build.bat",

--- a/build.bat
+++ b/build.bat
@@ -78,7 +78,7 @@
 @echo.
 @echo  Usage: %BLD_THIS% [help^|svl^|clean^|bootload]
 @echo    help      print these help details
-@echo    svl       compile, link, and create binary (default)
+@echo    svl       create binary for use with SF SVL bootloader (default)
 @echo    clean     delete all intermediate and binary files
 @echo    bootload  load binary using the SF SVL bootloader
 @goto :BLD_END


### PR DESCRIPTION
Update the build task description such that when you execute 'Run Build Task' in Visual Studio Code it's clear you're building a binary for use with the SF SVL bootloader. Reflect this same verbiage in the usage output of build.bat.