### PR TITLE
Added new macro ARTEMIS_DEBUG_HALSTATUS

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Cortex Debug",
+      "name": "launch",
       "type": "cortex-debug",
       "request": "launch",
       "cwd": "${workspaceRoot}",
@@ -30,6 +30,32 @@
       "svdFile": "${workspaceRoot}/AmbiqSuiteSDK/pack/SVD/apollo3.svd",
       "executable": "${workspaceRoot}/bin/output_svl.axf",
       "runToMain": true,
-    }
+    },
+    {
+      "name": "attach",
+      "type": "cortex-debug",
+      "request": "attach",
+      "cwd": "${workspaceRoot}",
+      "servertype": "jlink",
+      "serverpath": "C:/Program Files (x86)/SEGGER/JLink/JLinkGDBServerCL.exe",
+      "interface": "swd",
+      "swoConfig": {
+        "enabled": true,
+        "cpuFrequency": 48000000,
+        "swoFrequency": 2000000,
+        "source": "probe",
+        "decoders": [
+          {
+            "type": "console",
+            "label": "ITM",
+            "port": 0,
+            "encoding": "ascii"
+          }
+        ]
+      },
+      "device": "AMA3B1KK-KBR",
+      "svdFile": "${workspaceRoot}/AmbiqSuiteSDK/pack/SVD/apollo3.svd",
+      "executable": "${workspaceRoot}/bin/output_svl.axf",
+    },
   ]
 }

--- a/build.bat
+++ b/build.bat
@@ -50,7 +50,7 @@
 @set BLD_LIBRARY=%BLD_BOARDPATH%/bsp/gcc/bin/libam_bsp.a %BLD_SDKPATH%/mcu/%BLD_MCU%/hal/gcc/bin/libam_hal.a
 @set BLD_DEFINE=-DPART_%BLD_PART% -DAM_PART_%BLD_PART% -DAM_CUSTOM_BDADDR -DAM_PACKAGE_BGA -DAM_DEBUG_PRINTF -DWSF_TRACE_ENABLED
 @set BLD_CCFLAG=-mthumb -mcpu=%BLD_CPU% -mfpu=%BLD_FPU% -mfloat-abi=%BLD_FABI% -ffunction-sections -fdata-sections -std=c99 -Wall -g -O0 %BLD_DEFINE% %BLD_INCLUDE%
-@set BLD_LDFLAG=-mthumb -mcpu=%BLD_CPU% -mfpu=%BLD_FPU% -mfloat-abi=%BLD_FABI% --specs=nosys.specs -nostartfiles -static -Wl,--gc-sections,--entry,Reset_Handler,-Map,%BLD_BINPATH%/%BLD_OUTPUT%_svl.map -Wl,--start-group -lm -lc -lgcc %BLD_LIBRARY% -Wl,--end-group
+@set BLD_LDFLAG=-mthumb -mcpu=%BLD_CPU% -mfpu=%BLD_FPU% -mfloat-abi=%BLD_FABI% -nostartfiles -static -Wl,--gc-sections,--entry,Reset_Handler,-Map,%BLD_BINPATH%/%BLD_OUTPUT%_svl.map -Wl,--start-group -lm -lc -lgcc %BLD_LIBRARY% -Wl,--end-group
 
 @rem Verify the build environment
 %BLD_CC% --version >nul 2>&1

--- a/src/artemis_debug.c
+++ b/src/artemis_debug.c
@@ -4,7 +4,6 @@
 
 #include "artemis_debug.h"
 #include <am_bsp.h>
-#include <stdlib.h>
 
 ///
 ///
@@ -21,6 +20,27 @@ void artemis_debug_initialize(void)
 ///
 void artemis_debug_assert(const char *expr, const char *func, const char *file, uint32_t line)
 {
-    ARTEMIS_DEBUG_PRINTF("ASSERT FAILED:\n\texpr:\t%s\n\tfunc:\t%s\n\tfile:\t%s\n\tline:\t%u\n", expr, func, file, line);
-    abort();
+    ARTEMIS_DEBUG_PRINTF("ASSERT FAILED: {\n");
+    ARTEMIS_DEBUG_PRINTF("\texpr:\t%s\n", expr);
+    ARTEMIS_DEBUG_PRINTF("\tfunc:\t%s\n", func);
+    ARTEMIS_DEBUG_PRINTF("\tfile:\t%s\n", file);
+    ARTEMIS_DEBUG_PRINTF("\tline:\t%u\n", line);
+    ARTEMIS_DEBUG_PRINTF("}\n");
+
+    while(1);
+}
+
+///
+///
+///
+void artemis_debug_halerror(uint32_t error, const char *func, const char *file, uint32_t line)
+{
+    ARTEMIS_DEBUG_PRINTF("AM HAL ERROR: {\n");
+    ARTEMIS_DEBUG_PRINTF("\terror:\t%u\n", error);
+    ARTEMIS_DEBUG_PRINTF("\tfunc:\t%s\n", func);
+    ARTEMIS_DEBUG_PRINTF("\tfile:\t%s\n", file);
+    ARTEMIS_DEBUG_PRINTF("\tline:\t%u\n", line);
+    ARTEMIS_DEBUG_PRINTF("}\n");
+
+    while(1);
 }

--- a/src/artemis_debug.h
+++ b/src/artemis_debug.h
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <am_util_stdio.h>
+#include <hal/am_hal_status.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -17,14 +18,24 @@ extern "C" {
     #define ARTEMIS_DEBUG_ASSERT(expr) ((void)0)
     #define ARTEMIS_DEBUG_PRINTF(...) ((void)0)
     #define ARTEMIS_DEBUG_TASKINFO(name, elapsed_us) ((void)0)
+    #define ARTEMIS_DEBUG_HALSTATUS(func) (func)
 #else
     #define ARTEMIS_DEBUG_ASSERT(expr) (!!(expr) || (artemis_debug_assert(#expr, __FUNCTION__, __FILE__, __LINE__), 0))
     #define ARTEMIS_DEBUG_PRINTF(...) (am_util_stdio_printf(__VA_ARGS__))
     #define ARTEMIS_DEBUG_TASKINFO(name, elapsed_us) (am_util_stdio_printf("%s:\t\t%llu\n", name, elapsed_us))
+
+    #define ARTEMIS_DEBUG_HALSTATUS(func) \
+    do { \
+        uint32_t artemis_debug_halstatus = (func); \
+        if (artemis_debug_halstatus != AM_HAL_STATUS_SUCCESS) { \
+            artemis_debug_halerror(artemis_debug_halstatus, __FUNCTION__, __FILE__, __LINE__); \
+        } \
+    } while(0)
 #endif
 
 void artemis_debug_initialize(void);
 void artemis_debug_assert(const char *expr, const char *func, const char *file, uint32_t line);
+void artemis_debug_halerror(uint32_t error, const char *func, const char *file, uint32_t line);
 
 #ifdef __cplusplus
 }

--- a/src/artemis_i2c.c
+++ b/src/artemis_i2c.c
@@ -2,12 +2,13 @@
 /// @file artemis_i2c.c
 ///
 
+#include "artemis_debug.h"
 #include "artemis_i2c.h"
 
 ///
 ///
 ///
-bool artemis_i2c_send(artemis_i2c_t *i2c, bool stop, artemis_stream_t *txstream)
+void artemis_i2c_send(artemis_i2c_t *i2c, bool stop, artemis_stream_t *txstream)
 {
     am_hal_iom_transfer_t transfer = {0};
 
@@ -18,20 +19,16 @@ bool artemis_i2c_send(artemis_i2c_t *i2c, bool stop, artemis_stream_t *txstream)
     transfer.eDirection = AM_HAL_IOM_TX;
     transfer.ui8Priority = 1;
 
-    if (AM_HAL_STATUS_SUCCESS != am_hal_iom_blocking_transfer(i2c->iom.handle, &transfer)) {
-        return(false);
-    }
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_iom_blocking_transfer(i2c->iom.handle, &transfer));
 
     // update the number of bytes read from the txstream
     txstream->read = txstream->written;
-
-    return(true);
 }
 
 ///
 ///
 ///
-bool artemis_i2c_receive(artemis_i2c_t *i2c, bool stop, artemis_stream_t *rxstream, uint32_t rxnumber)
+void artemis_i2c_receive(artemis_i2c_t *i2c, bool stop, artemis_stream_t *rxstream, uint32_t rxnumber)
 {
     am_hal_iom_transfer_t transfer = {0};
 
@@ -42,12 +39,8 @@ bool artemis_i2c_receive(artemis_i2c_t *i2c, bool stop, artemis_stream_t *rxstre
     transfer.eDirection = AM_HAL_IOM_RX;
     transfer.ui8Priority = 1;
 
-    if (AM_HAL_STATUS_SUCCESS != am_hal_iom_blocking_transfer(i2c->iom.handle, &transfer)) {
-        return(false);
-    }
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_iom_blocking_transfer(i2c->iom.handle, &transfer));
 
     // update the number of bytes written to the rxstream
     rxstream->written = rxnumber;
-
-    return(true);
 }

--- a/src/artemis_i2c.h
+++ b/src/artemis_i2c.h
@@ -20,8 +20,8 @@ typedef struct s_artemis_i2c_t
     artemis_iom_t iom;
 } artemis_i2c_t;
 
-bool artemis_i2c_send(artemis_i2c_t *i2c, bool stop, artemis_stream_t *txstream);
-bool artemis_i2c_receive(artemis_i2c_t *i2c, bool stop, artemis_stream_t *rxstream, uint32_t rxnumber);
+void artemis_i2c_send(artemis_i2c_t *i2c, bool stop, artemis_stream_t *txstream);
+void artemis_i2c_receive(artemis_i2c_t *i2c, bool stop, artemis_stream_t *rxstream, uint32_t rxnumber);
 
 #ifdef __cplusplus
 }

--- a/src/artemis_icm20649.c
+++ b/src/artemis_icm20649.c
@@ -94,10 +94,10 @@ void artemis_icm20649_initialize(void)
     spi->iom.config.eSpiMode = AM_HAL_IOM_SPI_MODE_0;
     artemis_iom_initialize(&spi->iom);
 
-    am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_SCK, g_AM_BSP_GPIO_IOM0_SCK);
-    am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_MISO, g_AM_BSP_GPIO_IOM0_MISO);
-    am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_MOSI, g_AM_BSP_GPIO_IOM0_MOSI);
-    am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_CS, g_AM_BSP_GPIO_IOM0_CS);
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_SCK, g_AM_BSP_GPIO_IOM0_SCK));
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_MISO, g_AM_BSP_GPIO_IOM0_MISO));
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_MOSI, g_AM_BSP_GPIO_IOM0_MOSI));
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_CS, g_AM_BSP_GPIO_IOM0_CS));
 
     module_icm20649_reset();
     module_icm20649_identity();

--- a/src/artemis_iom.c
+++ b/src/artemis_iom.c
@@ -2,6 +2,7 @@
 /// @file artemis_iom.c
 ///
 
+#include "artemis_debug.h"
 #include "artemis_iom.h"
 
 ///
@@ -9,10 +10,10 @@
 ///
 void artemis_iom_initialize(artemis_iom_t *iom)
 {
-    am_hal_iom_initialize(iom->module, &iom->handle);
-    am_hal_iom_power_ctrl(iom->handle, AM_HAL_SYSCTRL_WAKE, false);
-    am_hal_iom_configure(iom->handle, &iom->config);
-    am_hal_iom_enable(iom->handle);
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_iom_initialize(iom->module, &iom->handle));
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_iom_power_ctrl(iom->handle, AM_HAL_SYSCTRL_WAKE, false));
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_iom_configure(iom->handle, &iom->config));
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_iom_enable(iom->handle));
 }
 
 ///
@@ -20,8 +21,8 @@ void artemis_iom_initialize(artemis_iom_t *iom)
 ///
 void artemis_iom_uninitialize(artemis_iom_t *iom)
 {
-    am_hal_iom_disable(iom->handle);
-    am_hal_iom_power_ctrl(iom->handle, AM_HAL_SYSCTRL_DEEPSLEEP, false);
-    am_hal_iom_uninitialize(iom->handle);
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_iom_disable(iom->handle));
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_iom_power_ctrl(iom->handle, AM_HAL_SYSCTRL_DEEPSLEEP, false));
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_iom_uninitialize(iom->handle));
     iom->handle = 0;
 }

--- a/src/artemis_mcu.c
+++ b/src/artemis_mcu.c
@@ -2,6 +2,7 @@
 /// @file artemis_mcu.c
 ///
 
+#include "artemis_debug.h"
 #include "artemis_mcu.h"
 #include <am_bsp.h>
 
@@ -13,23 +14,23 @@ void artemis_mcu_initialize(void)
     am_hal_burst_avail_e burst_avail;
 
     // set the clock frequency
-    am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_SYSCLK_MAX, 0);
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_SYSCLK_MAX, 0));
 
     // set the default cache configuration
-    am_hal_cachectrl_config(&am_hal_cachectrl_defaults);
-    am_hal_cachectrl_enable();
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_cachectrl_config(&am_hal_cachectrl_defaults));
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_cachectrl_enable());
 
     // enable the floating point module
     am_hal_sysctrl_fpu_enable();
 
     // initialize mcu for burst mode operations
-    am_hal_burst_mode_initialize(&burst_avail);
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_burst_mode_initialize(&burst_avail));
 
     // configure the board for low power operation
     // am_bsp_low_power_init();
 
     // enable interrupts
-    am_hal_interrupt_master_enable();
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_interrupt_master_enable());
 }
 
 ///
@@ -39,7 +40,7 @@ void artemis_mcu_enableburst(void)
 {
     am_hal_burst_mode_e burst_mode;
 
-    am_hal_burst_mode_enable(&burst_mode);
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_burst_mode_enable(&burst_mode));
 }
 
 ///
@@ -49,5 +50,5 @@ void artemis_mcu_disableburst(void)
 {
     am_hal_burst_mode_e burst_mode;
 
-    am_hal_burst_mode_disable(&burst_mode);
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_burst_mode_disable(&burst_mode));
 }

--- a/src/artemis_pca9685.c
+++ b/src/artemis_pca9685.c
@@ -5,6 +5,7 @@
 /// https://www.adafruit.com/product/815
 ///
 
+#include "artemis_debug.h"
 #include "artemis_i2c.h"
 #include "artemis_math.h"
 #include "artemis_pca9685.h"
@@ -82,8 +83,8 @@ void artemis_pca9685_initialize(uint16_t frequency)
     i2c->iom.config.ui32ClockFreq = AM_HAL_IOM_400KHZ;
     artemis_iom_initialize(&i2c->iom);
 
-    am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_SCL, g_AM_BSP_GPIO_IOM4_SCL);
-    am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_SDA, g_AM_BSP_GPIO_IOM4_SDA);
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_SCL, g_AM_BSP_GPIO_IOM4_SCL));
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_SDA, g_AM_BSP_GPIO_IOM4_SDA));
 
     module_pca9685_reset();
     module_pca9685_setfrequency(frequency);

--- a/src/artemis_spi.c
+++ b/src/artemis_spi.c
@@ -2,12 +2,13 @@
 /// @file artemis_spi.c
 ///
 
+#include "artemis_debug.h"
 #include "artemis_spi.h"
 
 ///
 ///
 ///
-bool artemis_spi_send(artemis_spi_t *spi, bool stop, artemis_stream_t *txstream)
+void artemis_spi_send(artemis_spi_t *spi, bool stop, artemis_stream_t *txstream)
 {
     am_hal_iom_transfer_t transfer = {0};
 
@@ -18,20 +19,16 @@ bool artemis_spi_send(artemis_spi_t *spi, bool stop, artemis_stream_t *txstream)
     transfer.eDirection = AM_HAL_IOM_TX;
     transfer.ui8Priority = 1;
 
-    if (AM_HAL_STATUS_SUCCESS != am_hal_iom_blocking_transfer(spi->iom.handle, &transfer)) {
-        return(false);
-    }
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_iom_blocking_transfer(spi->iom.handle, &transfer));
 
     // update the number of bytes read from the txstream
     txstream->read = txstream->written;
-
-    return(true);
 }
 
 ///
 ///
 ///
-bool artemis_spi_receive(artemis_spi_t *spi, bool stop, artemis_stream_t *rxstream, uint32_t rxnumber)
+void artemis_spi_receive(artemis_spi_t *spi, bool stop, artemis_stream_t *rxstream, uint32_t rxnumber)
 {
     am_hal_iom_transfer_t transfer = {0};
 
@@ -42,20 +39,16 @@ bool artemis_spi_receive(artemis_spi_t *spi, bool stop, artemis_stream_t *rxstre
     transfer.eDirection = AM_HAL_IOM_RX;
     transfer.ui8Priority = 1;
 
-    if (AM_HAL_STATUS_SUCCESS != am_hal_iom_blocking_transfer(spi->iom.handle, &transfer)) {
-        return(false);
-    }
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_iom_blocking_transfer(spi->iom.handle, &transfer));
 
     // update the number of bytes written to the rxstream
     rxstream->written = rxnumber;
-
-    return(true);
 }
 
 ///
 ///
 ///
-bool artemis_spi_transfer(artemis_spi_t *spi, bool stop, artemis_stream_t *txstream, artemis_stream_t *rxstream)
+void artemis_spi_transfer(artemis_spi_t *spi, bool stop, artemis_stream_t *txstream, artemis_stream_t *rxstream)
 {
     am_hal_iom_transfer_t transfer = {0};
 
@@ -67,15 +60,11 @@ bool artemis_spi_transfer(artemis_spi_t *spi, bool stop, artemis_stream_t *txstr
     transfer.eDirection = AM_HAL_IOM_FULLDUPLEX;
     transfer.ui8Priority = 1;
 
-    if (AM_HAL_STATUS_SUCCESS != am_hal_iom_spi_blocking_fullduplex(spi->iom.handle, &transfer)) {
-        return(false);
-    }
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_iom_spi_blocking_fullduplex(spi->iom.handle, &transfer));
 
     // update the number of bytes read from the txstream
     txstream->read = txstream->written;
 
     // update the number of bytes written to the rxstream
     rxstream->written = txstream->written;
-
-    return(true);
 }

--- a/src/artemis_spi.h
+++ b/src/artemis_spi.h
@@ -23,9 +23,9 @@ typedef struct s_artemis_spi_t
     artemis_iom_t iom;
 } artemis_spi_t;
 
-bool artemis_spi_send(artemis_spi_t *spi, bool stop, artemis_stream_t *txstream);
-bool artemis_spi_receive(artemis_spi_t *spi, bool stop, artemis_stream_t *rxstream, uint32_t rxnumber);
-bool artemis_spi_transfer(artemis_spi_t *spi, bool stop, artemis_stream_t *txstream, artemis_stream_t *rxstream);
+void artemis_spi_send(artemis_spi_t *spi, bool stop, artemis_stream_t *txstream);
+void artemis_spi_receive(artemis_spi_t *spi, bool stop, artemis_stream_t *rxstream, uint32_t rxnumber);
+void artemis_spi_transfer(artemis_spi_t *spi, bool stop, artemis_stream_t *txstream, artemis_stream_t *rxstream);
 
 #ifdef __cplusplus
 }

--- a/src/artemis_util.h
+++ b/src/artemis_util.h
@@ -15,6 +15,7 @@ extern "C" {
 #define ARTEMIS_UTIL_ARRAY_SIZE(a)    (sizeof(a) / sizeof(a[0]))
 #define ARTEMIS_UTIL_OFFSET(s, m)     (offsetof(s, m))
 #define ARTEMIS_UTIL_OFFSET_PTR(s, m) ((uint8_t*)0 + offsetof(s, m))
+#define ARTEMIS_UTIL_UNUSED(v)        ((void)(v))
 
 #ifdef __cplusplus
 }

--- a/src/artemis_watchdog.c
+++ b/src/artemis_watchdog.c
@@ -23,8 +23,8 @@ static module_t module;
 ///
 void artemis_watchdog_initialize(void)
 {
-    am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_LFRC_START, 0);
-    am_hal_reset_control(AM_HAL_RESET_CONTROL_STATUSCLEAR, 0);
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_LFRC_START, 0));
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_reset_control(AM_HAL_RESET_CONTROL_STATUSCLEAR, 0));
 
     NVIC_EnableIRQ(WDT_IRQn);
 


### PR DESCRIPTION
Added new macro ARTEMIS_DEBUG_HALSTATUS which should be used for all am_hal_xxx() functions. In the event a HAL function fails, it will call artemis_debug_halerror() and block on while(1). This same approach (i.e. blocking on while(1)) is now also used for ARTEMIS_DEBUG_ASSERT. This facilitates attaching to the MCU and analyzing the error. To enable attaching, a new debug configuration 'attach' was added to launch.json. The previous configuration was renamed 'launch'. With these two debug configurations you can now attach to the MCU (without restarting it) or launch from the beginning (restarting it) which stops at main().