### PR TITLE
Moved ARTEMIS_DEBUG_TASKINFO to ARTEMIS_TASK_TIME

### DIFF
--- a/src/artemis_core.c
+++ b/src/artemis_core.c
@@ -3,8 +3,8 @@
 ///
 
 #include "artemis_core.h"
-#include "artemis_debug.h"
 #include "artemis_servo.h"
+#include "artemis_task.h"
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -30,7 +30,7 @@ void artemis_core_update(const char *name, uint64_t elapsed_us)
 {
     artemis_servo_t *servo;
 
-    ARTEMIS_DEBUG_TASKINFO(name, elapsed_us);
+    ARTEMIS_TASK_TIME(name, elapsed_us);
 
     for (size_t i = 0; i < ARTEMIS_SERVO_INDEX_COUNT; i++) {
         servo = artemis_servo_get(i);

--- a/src/artemis_debug.h
+++ b/src/artemis_debug.h
@@ -17,12 +17,10 @@ extern "C" {
 #ifdef NDEBUG
     #define ARTEMIS_DEBUG_ASSERT(expr) ((void)0)
     #define ARTEMIS_DEBUG_PRINTF(...) ((void)0)
-    #define ARTEMIS_DEBUG_TASKINFO(name, elapsed_us) ((void)0)
     #define ARTEMIS_DEBUG_HALSTATUS(func) (func)
 #else
     #define ARTEMIS_DEBUG_ASSERT(expr) (!!(expr) || (artemis_debug_assert(#expr, __FUNCTION__, __FILE__, __LINE__), 0))
     #define ARTEMIS_DEBUG_PRINTF(...) (am_util_stdio_printf(__VA_ARGS__))
-    #define ARTEMIS_DEBUG_TASKINFO(name, elapsed_us) (am_util_stdio_printf("%s:\t\t%llu\n", name, elapsed_us))
 
     #define ARTEMIS_DEBUG_HALSTATUS(func) \
     do { \

--- a/src/artemis_imu.c
+++ b/src/artemis_imu.c
@@ -2,9 +2,9 @@
 /// @file artemis_imu.c
 ///
 
-#include "artemis_debug.h"
 #include "artemis_icm20649.h"
 #include "artemis_imu.h"
+#include "artemis_task.h"
 
 ///
 ///
@@ -22,7 +22,7 @@ void artemis_imu_update(const char *name, uint64_t elapsed_us)
     artemis_icm20649_data_t accel;
     artemis_icm20649_data_t gyro;
 
-    ARTEMIS_DEBUG_TASKINFO(name, elapsed_us);
+    ARTEMIS_TASK_TIME(name, elapsed_us);
 
     artemis_icm20649_readaccel(&accel);
     artemis_icm20649_readgyro(&gyro);

--- a/src/artemis_led.c
+++ b/src/artemis_led.c
@@ -4,6 +4,7 @@
 
 #include "artemis_debug.h"
 #include "artemis_led.h"
+#include "artemis_task.h"
 #include <am_bsp.h>
 
 typedef struct s_module_t
@@ -18,7 +19,8 @@ static module_t module;
 ///
 void artemis_led_initialize(void)
 {
-    am_hal_gpio_pinconfig(AM_BSP_GPIO_LED_BLUE, g_AM_HAL_GPIO_OUTPUT);
+    ARTEMIS_DEBUG_HALSTATUS(am_hal_gpio_pinconfig(AM_BSP_GPIO_LED_BLUE, g_AM_HAL_GPIO_OUTPUT));
+
     am_devices_led_off(am_bsp_psLEDs, AM_BSP_LED_BLUE);
 }
 
@@ -27,7 +29,7 @@ void artemis_led_initialize(void)
 ///
 void artemis_led_toggle(const char *name, uint64_t elapsed_us)
 {
-    ARTEMIS_DEBUG_TASKINFO(name, elapsed_us);
+    ARTEMIS_TASK_TIME(name, elapsed_us);
 
     module.state = !module.state;
 

--- a/src/artemis_servo.c
+++ b/src/artemis_servo.c
@@ -2,9 +2,9 @@
 /// @file artemis_servo.c
 ///
 
-#include "artemis_debug.h"
 #include "artemis_pca9685.h"
 #include "artemis_servo.h"
+#include "artemis_task.h"
 #include <stddef.h>
 
 typedef struct s_module_t
@@ -39,7 +39,7 @@ void artemis_servo_update(const char *name, uint64_t elapsed_us)
 {
     artemis_servo_t *servo;
 
-    ARTEMIS_DEBUG_TASKINFO(name, elapsed_us);
+    ARTEMIS_TASK_TIME(name, elapsed_us);
 
     for (size_t i = 0; i < ARTEMIS_SERVO_INDEX_COUNT; i++) {
         servo = &module.servos[i];

--- a/src/artemis_task.h
+++ b/src/artemis_task.h
@@ -5,10 +5,18 @@
 #ifndef ARTEMIS_TASK_H
 #define ARTEMIS_TASK_H
 
+#include <stdbool.h>
 #include <stdint.h>
+#include <am_util_stdio.h>
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+#ifdef NTASKTIME
+    #define ARTEMIS_TASK_TIME(name, elapsed_us) ((void)0)
+#else
+    #define ARTEMIS_TASK_TIME(name, elapsed_us) (am_util_stdio_printf("%s:\t\t%llu\n", name, elapsed_us))
 #endif
 
 typedef enum e_artemis_task_id_t

--- a/src/artemis_watchdog.c
+++ b/src/artemis_watchdog.c
@@ -4,6 +4,7 @@
 
 #include "artemis_debug.h"
 #include "artemis_watchdog.h"
+#include "artemis_task.h"
 #include <am_bsp.h>
 
 #define ARTEMIS_WATCHDOG_LFRC_16HZ         (16) // 8-bit counter; 2^8 / 16Hz = 16 second max timeout
@@ -42,7 +43,7 @@ void artemis_watchdog_initialize(void)
 ///
 void artemis_watchdog_restart(const char *name, uint64_t elapsed_us)
 {
-    ARTEMIS_DEBUG_TASKINFO(name, elapsed_us);
+    ARTEMIS_TASK_TIME(name, elapsed_us);
 
     am_hal_wdt_restart();
 }


### PR DESCRIPTION
Moved ARTEMIS_DEBUG_TASKINFO to ARTEMIS_TASK_TIME to allow disabling of task information being printed while still allowing other pertinent debug information to be printed. Disabling task information is done by defining NTASKTIME.