### PR TITLE
Added parameter to artemis_debug_halerror()

### DIFF
--- a/src/artemis_debug.c
+++ b/src/artemis_debug.c
@@ -33,9 +33,10 @@ void artemis_debug_assert(const char *expr, const char *func, const char *file, 
 ///
 ///
 ///
-void artemis_debug_halerror(uint32_t error, const char *func, const char *file, uint32_t line)
+void artemis_debug_halerror(const char *hfunc, uint32_t error, const char *func, const char *file, uint32_t line)
 {
     ARTEMIS_DEBUG_PRINTF("AM HAL ERROR: {\n");
+    ARTEMIS_DEBUG_PRINTF("\thfunc:\t%s\n", hfunc);
     ARTEMIS_DEBUG_PRINTF("\terror:\t%u\n", error);
     ARTEMIS_DEBUG_PRINTF("\tfunc:\t%s\n", func);
     ARTEMIS_DEBUG_PRINTF("\tfile:\t%s\n", file);

--- a/src/artemis_debug.h
+++ b/src/artemis_debug.h
@@ -17,23 +17,23 @@ extern "C" {
 #ifdef NDEBUG
     #define ARTEMIS_DEBUG_ASSERT(expr) ((void)0)
     #define ARTEMIS_DEBUG_PRINTF(...) ((void)0)
-    #define ARTEMIS_DEBUG_HALSTATUS(func) (func)
+    #define ARTEMIS_DEBUG_HALSTATUS(hfunc) (hfunc)
 #else
     #define ARTEMIS_DEBUG_ASSERT(expr) (!!(expr) || (artemis_debug_assert(#expr, __FUNCTION__, __FILE__, __LINE__), 0))
     #define ARTEMIS_DEBUG_PRINTF(...) (am_util_stdio_printf(__VA_ARGS__))
 
-    #define ARTEMIS_DEBUG_HALSTATUS(func) \
+    #define ARTEMIS_DEBUG_HALSTATUS(hfunc) \
     do { \
-        uint32_t artemis_debug_halstatus = (func); \
+        uint32_t artemis_debug_halstatus = (hfunc); \
         if (artemis_debug_halstatus != AM_HAL_STATUS_SUCCESS) { \
-            artemis_debug_halerror(artemis_debug_halstatus, __FUNCTION__, __FILE__, __LINE__); \
+            artemis_debug_halerror(#hfunc, artemis_debug_halstatus, __FUNCTION__, __FILE__, __LINE__); \
         } \
     } while(0)
 #endif
 
 void artemis_debug_initialize(void);
 void artemis_debug_assert(const char *expr, const char *func, const char *file, uint32_t line);
-void artemis_debug_halerror(uint32_t error, const char *func, const char *file, uint32_t line);
+void artemis_debug_halerror(const char *hfunc, uint32_t error, const char *func, const char *file, uint32_t line);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Added parameter to artemis_debug_halerror() which captures the hal function that failed such that it can be printed.