### PR TITLE
TASKTIME macro is now private to artemis_scheduler.

### DIFF
--- a/src/artemis_core.c
+++ b/src/artemis_core.c
@@ -4,7 +4,6 @@
 
 #include "artemis_core.h"
 #include "artemis_servo.h"
-#include "artemis_task.h"
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -26,11 +25,9 @@ void artemis_core_initialize(void)
 ///
 ///
 ///
-void artemis_core_update(const char *name, uint64_t elapsed_us)
+void artemis_core_update(uint64_t elapsed_us)
 {
     artemis_servo_t *servo;
-
-    ARTEMIS_TASK_TIME(name, elapsed_us);
 
     for (size_t i = 0; i < ARTEMIS_SERVO_INDEX_COUNT; i++) {
         servo = artemis_servo_get(i);

--- a/src/artemis_core.h
+++ b/src/artemis_core.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 void artemis_core_initialize(void);
-void artemis_core_update(const char *name, uint64_t elapsed_us);
+void artemis_core_update(uint64_t elapsed_us);
 
 #ifdef __cplusplus
 }

--- a/src/artemis_imu.c
+++ b/src/artemis_imu.c
@@ -4,7 +4,6 @@
 
 #include "artemis_icm20649.h"
 #include "artemis_imu.h"
-#include "artemis_task.h"
 
 ///
 ///
@@ -17,12 +16,10 @@ void artemis_imu_initialize(void)
 ///
 ///
 ///
-void artemis_imu_update(const char *name, uint64_t elapsed_us)
+void artemis_imu_update(uint64_t elapsed_us)
 {
     artemis_icm20649_data_t accel;
     artemis_icm20649_data_t gyro;
-
-    ARTEMIS_TASK_TIME(name, elapsed_us);
 
     artemis_icm20649_readaccel(&accel);
     artemis_icm20649_readgyro(&gyro);

--- a/src/artemis_imu.h
+++ b/src/artemis_imu.h
@@ -20,7 +20,7 @@ typedef enum e_artemis_imu_axis_t
 } artemis_imu_axis_t;
 
 void artemis_imu_initialize(void);
-void artemis_imu_update(const char *name, uint64_t elapsed_us);
+void artemis_imu_update(uint64_t elapsed_us);
 
 #ifdef __cplusplus
 }

--- a/src/artemis_led.c
+++ b/src/artemis_led.c
@@ -4,7 +4,6 @@
 
 #include "artemis_debug.h"
 #include "artemis_led.h"
-#include "artemis_task.h"
 #include <am_bsp.h>
 
 typedef struct s_module_t
@@ -27,10 +26,8 @@ void artemis_led_initialize(void)
 ///
 ///
 ///
-void artemis_led_toggle(const char *name, uint64_t elapsed_us)
+void artemis_led_toggle(uint64_t elapsed_us)
 {
-    ARTEMIS_TASK_TIME(name, elapsed_us);
-
     module.state = !module.state;
 
     if (module.state) {

--- a/src/artemis_led.h
+++ b/src/artemis_led.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 void artemis_led_initialize(void);
-void artemis_led_toggle(const char *name, uint64_t elapsed_us);
+void artemis_led_toggle(uint64_t elapsed_us);
 
 #ifdef __cplusplus
 }

--- a/src/artemis_scheduler.c
+++ b/src/artemis_scheduler.c
@@ -5,8 +5,16 @@
 #include "artemis_scheduler.h"
 #include "artemis_task.h"
 #include "artemis_time.h"
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <am_util_stdio.h>
+
+#ifdef NTASKTIME
+    #define ARTEMIS_SCHEDULER_TASKTIME(name, elapsed_us) ((void)0)
+#else
+    #define ARTEMIS_SCHEDULER_TASKTIME(name, elapsed_us) (am_util_stdio_printf("%s:\t\t%llu\n", name, elapsed_us))
+#endif
 
 ///
 ///
@@ -39,8 +47,9 @@ void artemis_scheduler_run(void)
             elapsed_us = current_us - task->previous_us;
 
             if (elapsed_us >= ARTEMIS_TIME_HZ_TO_US(task->period_hz)) {
+                ARTEMIS_SCHEDULER_TASKTIME(task->name, elapsed_us);
                 task->previous_us = current_us;
-                task->run(task->name, elapsed_us);
+                task->run(elapsed_us);
             }
         }
     }

--- a/src/artemis_servo.c
+++ b/src/artemis_servo.c
@@ -4,7 +4,6 @@
 
 #include "artemis_pca9685.h"
 #include "artemis_servo.h"
-#include "artemis_task.h"
 #include <stddef.h>
 
 typedef struct s_module_t
@@ -35,11 +34,9 @@ void artemis_servo_initialize(void)
 ///
 ///
 ///
-void artemis_servo_update(const char *name, uint64_t elapsed_us)
+void artemis_servo_update(uint64_t elapsed_us)
 {
     artemis_servo_t *servo;
-
-    ARTEMIS_TASK_TIME(name, elapsed_us);
 
     for (size_t i = 0; i < ARTEMIS_SERVO_INDEX_COUNT; i++) {
         servo = &module.servos[i];

--- a/src/artemis_servo.h
+++ b/src/artemis_servo.h
@@ -42,7 +42,7 @@ typedef struct s_artemis_servo_t
 } artemis_servo_t;
 
 void artemis_servo_initialize(void);
-void artemis_servo_update(const char *name, uint64_t elapsed_us);
+void artemis_servo_update(uint64_t elapsed_us);
 artemis_servo_t *artemis_servo_get(artemis_servo_index_t index);
 
 #ifdef __cplusplus

--- a/src/artemis_task.h
+++ b/src/artemis_task.h
@@ -5,18 +5,10 @@
 #ifndef ARTEMIS_TASK_H
 #define ARTEMIS_TASK_H
 
-#include <stdbool.h>
 #include <stdint.h>
-#include <am_util_stdio.h>
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifdef NTASKTIME
-    #define ARTEMIS_TASK_TIME(name, elapsed_us) ((void)0)
-#else
-    #define ARTEMIS_TASK_TIME(name, elapsed_us) (am_util_stdio_printf("%s:\t\t%llu\n", name, elapsed_us))
 #endif
 
 typedef enum e_artemis_task_id_t
@@ -33,7 +25,7 @@ typedef struct s_artemis_task_t
 {
     const char *name;
     void (*initialize)(void);
-    void (*run)(const char *name, uint64_t elapsed_us);
+    void (*run)(uint64_t elapsed_us);
     uint16_t period_hz;
     uint64_t previous_us;
 } artemis_task_t;

--- a/src/artemis_watchdog.c
+++ b/src/artemis_watchdog.c
@@ -4,7 +4,6 @@
 
 #include "artemis_debug.h"
 #include "artemis_watchdog.h"
-#include "artemis_task.h"
 #include <am_bsp.h>
 
 #define ARTEMIS_WATCHDOG_LFRC_16HZ         (16) // 8-bit counter; 2^8 / 16Hz = 16 second max timeout
@@ -41,10 +40,8 @@ void artemis_watchdog_initialize(void)
 ///
 ///
 ///
-void artemis_watchdog_restart(const char *name, uint64_t elapsed_us)
+void artemis_watchdog_restart(uint64_t elapsed_us)
 {
-    ARTEMIS_TASK_TIME(name, elapsed_us);
-
     am_hal_wdt_restart();
 }
 

--- a/src/artemis_watchdog.h
+++ b/src/artemis_watchdog.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 void artemis_watchdog_initialize(void);
-void artemis_watchdog_restart(const char *name, uint64_t elapsed_us);
+void artemis_watchdog_restart(uint64_t elapsed_us);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Instead of each run() function individually printing their task name and elapsed time via the TASKTIME macro the call has been centralized in the scheduler loop. This eliminates #include "artemis_task.h" all over the place simply for that macro. Much simpler and more concise. It can still be disabled by defining NTASKTIME.